### PR TITLE
Add printer availability notifications and feature summary

### DIFF
--- a/listoffeatures.md
+++ b/listoffeatures.md
@@ -1,0 +1,22 @@
+# Printbox Feature Overview and Recommendations
+
+## Core Capabilities
+- **Email polling and processing** via Gmail IMAP credentials defined in `config.py`. The system scans unread messages, downloads PDF attachments, and prepares them for printing.
+- **Automatic PDF preparation** including optional reversal of page order and enforcing single-sided, letter-sized, fit-to-page printing defaults.
+- **Print job submission** to the configured CUPS printer using `lp` with standard options for reliability.
+- **Operational logging** captured as JSON entries with timestamps for key events (printing, missing attachments, errors, and printer availability). Logs are accessible through the admin panel utilities.
+- **Admin utilities** offering command-line access to printer status, job queue inspection, recent log entries, and manual inbox polling.
+- **Simple alternate script** (`printbox_simple.py`) that performs basic polling and printing with lightweight logging, useful for debugging or fallback scenarios.
+
+## Newly Added Reliability Enhancements
+- **SMTP notifications when the printer is unavailable**, automatically informing senders that their request cannot be fulfilled at the moment.
+- **Printer availability checks with structured logging**, capturing both successful detection and error cases (missing `lpstat`, offline printer, etc.) for easier diagnostics.
+
+## Recommended Next Steps
+- **Centralize configuration** by turning Gmail credentials, file paths, and printer names into environment-variable-driven settings to simplify deployment to new hosts and protect secrets.
+- **Harden logging** with rotation or size limits (e.g., via Python's `logging` module) to prevent JSON log files from growing unbounded and to enrich entries with severity levels.
+- **Expand failure handling**: consider retry logic for transient SMTP/IMAP issues and queue emails for deferred printing once a printer becomes available.
+- **Validation and testing**: add unit tests for helper functions (PDF reversal, log writing) and integration smoke tests that mock external dependencies (`imaplib`, `smtplib`, `subprocess`).
+- **Observability integration**: expose metrics (e.g., processed emails, print success rate) via a lightweight HTTP endpoint or push them to a monitoring service for proactive alerting.
+- **Security review**: evaluate the need for whitelisting senders, scanning attachments for malware, and encrypting log data containing personally identifiable information.
+


### PR DESCRIPTION
## Summary
- notify email senders when the configured printer is unavailable and log printer detection results
- add SMTP helper to send notifications and log success or failure
- document existing capabilities and future hardening ideas in listoffeatures.md

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d57b9112bc8330b36aa651a64ad232